### PR TITLE
adds "AllChannelStatus" to VMB2BL module

### DIFF
--- a/protocol.json
+++ b/protocol.json
@@ -2890,6 +2890,7 @@
          "Version" : "edition 1 _ rev7"
       },
       "09" : {
+         "AllChannelStatus" : "FF",
          "ChannelNumbers" : {
             "Name" : {
                "Map" : {

--- a/protocol.json
+++ b/protocol.json
@@ -25579,6 +25579,48 @@
          "Version" : "edition 1"
       },
       "43" : {
+         "Channels" : {
+            "01" : {
+               "Editable" : "yes",
+               "Name" : "Input",
+               "Type" : "Button"
+            },
+            "02" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 1",
+               "Type" : "Button"
+            },
+            "03" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 2",
+               "Type" : "Button"
+            },
+            "04" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 3",
+               "Type" : "Button"
+            },
+            "05" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 4",
+               "Type" : "Button"
+            },
+            "06" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 5",
+               "Type" : "Button"
+            },
+            "07" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 6",
+               "Type" : "Button"
+            },
+            "08" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 7",
+               "Type" : "Button"
+            }
+         },
          "File" : "protocol_vmbin.txt",
          "Info" : "One channel input module",
          "Messages" : {

--- a/protocol.json
+++ b/protocol.json
@@ -25367,6 +25367,48 @@
          "Version" : "edition 1"
       },
       "42" : {
+         "Channels" : {
+            "01" : {
+               "Editable" : "yes",
+               "Name" : "User group 1",
+               "Type" : "Button"
+            },
+            "02" : {
+               "Editable" : "yes",
+               "Name" : "User group 2",
+               "Type" : "Button"
+            },
+            "03" : {
+               "Editable" : "yes",
+               "Name" : "Tamper alarm",
+               "Type" : "Button"
+            },
+            "04" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 1",
+               "Type" : "Button"
+            },
+            "05" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 2",
+               "Type" : "Button"
+            },
+            "06" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 3",
+               "Type" : "Button"
+            },
+            "07" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 4",
+               "Type" : "Button"
+            },
+            "08" : {
+               "Editable" : "yes",
+               "Name" : "Virtual button 5",
+               "Type" : "Button"
+            }
+         },
          "File" : "protocol_vmbkp.txt",
          "Info" : "Keypad interface module",
          "Messages" : {


### PR DESCRIPTION
Hi, great work on aggregating this huge amount of documentation !
I'm not even entirely sure that I understand everything, but I believe that there is an "AllChannelStatus" missing for the VMB2BL module (at least it fixes a bug with Cereal2nd's velbus-aio library).

PS: I have the VMBKP, VMBRFR8S and VMBIN modules. I'm looking into adding the channel information for them.