### PR TITLE
adds "AllChannelStatus" to VMB2BL module

### DIFF
--- a/protocol.json
+++ b/protocol.json
@@ -2890,6 +2890,7 @@
          "Version" : "edition 1 _ rev7"
       },
       "09" : {
+         "AllChannelStatus" : "FF",
          "ChannelNumbers" : {
             "Name" : {
                "Map" : {


### PR DESCRIPTION
Hi, great work on aggregating this huge amount of documentation !
I'm not even entirely sure that I understand everything, but I believe that there is an "AllChannelStatus" missing for the VMB2BL module (at least it fixes a bug with Cereal2nd's velbus-aio library).

PS: I have the VMBKP, VMBRFR8S and VMBIN modules. I'm looking into adding the channel information for them.